### PR TITLE
Loosen schema types to only require UUID

### DIFF
--- a/app/graphql/types/area_attributes.rb
+++ b/app/graphql/types/area_attributes.rb
@@ -5,8 +5,8 @@ module Types
     description 'Attributes for creating an area'
     # TODO: can this be re-used for updates and if so how to mark everything optional
     argument :id, Integer, required: false
-    argument :uuid, String, required: false
-    argument :name, String, required: true
+    argument :uuid, String, required: true
+    argument :name, String, required: false
     argument :position, Integer, required: false
     argument :tombstone, Boolean, required: false
 

--- a/app/graphql/types/inspection_attributes.rb
+++ b/app/graphql/types/inspection_attributes.rb
@@ -3,10 +3,9 @@
 module Types
   class InspectionAttributes < Types::BaseInputObject
     description 'Attributes for creating an inspection'
-    # TODO: can this be re-used for updates and if so how to mark everything optional
     argument :id, Integer, required: false
-    argument :uuid, String, required: false
-    argument :name, String, required: true
+    argument :uuid, String, required: true
+    argument :name, String, required: false
     argument :note, String, required: false
     argument :tombstone, Boolean, required: false
 

--- a/app/graphql/types/item_attributes.rb
+++ b/app/graphql/types/item_attributes.rb
@@ -5,8 +5,8 @@ module Types
     description 'Attributes for creating an item'
     # TODO: can this be re-used for updates and if so how to mark everything optional
     argument :id, Integer, required: false
-    argument :uuid, String, required: false
-    argument :name, String, required: true
+    argument :uuid, String, required: true
+    argument :name, String, required: false
     argument :note, String, required: false
     argument :flagged, Boolean, required: false
     argument :position, Integer, required: false


### PR DESCRIPTION
This allows for incomplete patches to be received and processed by the server.
Client should logically only be sending mutations that would be valid and
sending creates in order.